### PR TITLE
avoid replacing an existing initialize method

### DIFF
--- a/lib/cls.rb
+++ b/lib/cls.rb
@@ -7,9 +7,11 @@ module Cls
 
   def define_initialize(args)
     assignments = args.map { |a| "@#{a} = #{a}" }.join("\n")
+    alias_method :given_initialize, :initialize
     self.class_eval %{
       def initialize(#{args.join(", ")})
                      #{assignments}
+          given_initialize
       end
     }
   end

--- a/spec/cls_spec.rb
+++ b/spec/cls_spec.rb
@@ -2,7 +2,11 @@ require "cls"
 
 class NamePresenter
   extend Cls
-  attr_reader :name
+  attr_reader :name, :initialized
+  def initialize
+    @initialized = true
+  end
+
   takes(:name)
   let(:yelled_name) { @name.upcase }
   let(:name_with_argument) { |other| }
@@ -49,6 +53,10 @@ describe Cls do
       expect do
         presenter.name_with_argument
       end.to raise_error(ArgumentError)
+    end
+
+    it 'should run the original initialize method' do
+        expect(presenter.initialized).to eq(true)
     end
   end
 


### PR DESCRIPTION
Thanks for the informative screencast!

I feel like there may be times when you want to do something on initialization, but you'd also like to make use of the 'takes' feature. I made a small change so that if an `initialize` method is already defined when we call `takes`, it will be preserved and executed after the instance method assignment. Perhaps this is a dumb idea. What do you think?